### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Vineyard 
+# Vineyard 
 [![Build Status](https://travis-ci.org/hitherejoe/Vineyard.svg?branch=master)](https://travis-ci.org/hitherejoe/Vineyard) [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-Vineyard-brightgreen.svg?style=flat)](http://android-arsenal.com/details/3/2963) [![Android Weekly] (https://img.shields.io/badge/Android%20Weekly-%23186-blue.svg)](http://androidweekly.net/issues/issue-186) [![Sidebar] (https://img.shields.io/badge/Sidebar-02%2F01%2F2016-orange.svg)](http://sidebar.io/2016/1/2) [![Open Source Android Apps] (https://img.shields.io/badge/Open%20Source%20Android%20Apps-Android%20TV-green.svg)](https://github.com/pcqpcq/open-source-android-apps)
 ========
 
@@ -21,9 +21,9 @@ Release 1.0 of the application allows you to:
 - View video grids for Users and Hashtags
 - Toggle the Auto-Loop option via Settings
 
-#Screens
+# Screens
 
-##[Browse Fragment](/app/src/main/java/com/hitherejoe/vineyard/ui/fragment/MainFragment.java)
+## [Browse Fragment](/app/src/main/java/com/hitherejoe/vineyard/ui/fragment/MainFragment.java)
 
 The browse fragment is what is used to display the browseable categories, post and options card. The
 [Icon Header Item Presenter](/app/src/main/java/com/hitherejoe/vineyard/ui/presenter/IconHeaderItemPresenter.java) is used
@@ -39,7 +39,7 @@ the option and error message cards.
 </p>
 
 
-##[Playback Activity](/app/src/main/java/com/hitherejoe/vineyard/ui/activity/PlaybackActivity.java)
+## [Playback Activity](/app/src/main/java/com/hitherejoe/vineyard/ui/activity/PlaybackActivity.java)
 
 The Playback Activity is used to play the video from a Vine post. Which used the [PlaybackOverlayFragment](/app/src/main/java/com/hitherejoe/vineyard/ui/fragment/PlaybackOverlayFragment.java) to display the playback controls over the top of the PlaybackActivity.
 
@@ -52,7 +52,7 @@ The Playback Activity is used to play the video from a Vine post. Which used the
 </p>
 
 
-##[Search Fragment](/app/src/main/java/com/hitherejoe/vineyard/ui/fragment/SearchFragment.java)
+## [Search Fragment](/app/src/main/java/com/hitherejoe/vineyard/ui/fragment/SearchFragment.java)
 
 The Search Fragment allows users to search for Vine Posts by either tags or usernames. The
 [Tag Presenter](/app/src/main/java/com/hitherejoe/vineyard/ui/presenter/TagPresenter.java) is used to
@@ -67,7 +67,7 @@ result becomes focused.
     <img src="images/search_no_results.png" alt="Search No Results"/>
 </p>
 
-##[Post Grid Fragment](/app/src/main/java/com/hitherejoe/vineyard/ui/fragment/PostGridFragment.java)
+## [Post Grid Fragment](/app/src/main/java/com/hitherejoe/vineyard/ui/fragment/PostGridFragment.java)
 
 The Post Grid Fragment is used to show a grid of videos from either a Hashtag or User feed. This screen
 is launched when a hashtag/username result is clicked in the [Search Fragment](/app/src/main/java/com/hitherejoe/vineyard/ui/fragment/SearchFragment.java).
@@ -76,7 +76,7 @@ is launched when a hashtag/username result is clicked in the [Search Fragment](/
     <img src="images/post_grid.png" alt="Post Grid"/>
 </p>
 
-##[AutoLoop Step Fragment](/app/src/main/java/com/hitherejoe/vineyard/ui/fragment/AutoLoopStepFragment.java)
+## [AutoLoop Step Fragment](/app/src/main/java/com/hitherejoe/vineyard/ui/fragment/AutoLoopStepFragment.java)
 
 The AutoLoop Step Fragment is used to toggle the AutoLoop setting for post videos. When enabled,
 videos will automatically loop until the video is either stopped or skipped. If this is not enabled
@@ -86,11 +86,11 @@ then videos will automatically play until the final one in the playlist is reach
     <img src="images/settings.png" alt="Settings"/>
 </p>
 
-#Custom Components
+# Custom Components
 
 Many of the screens used some of these custom components created especially for the needs of this app:
 
-##[Video Card View](/app/src/main/java/com/hitherejoe/vineyard/ui/widget/VideoCardView.java)
+## [Video Card View](/app/src/main/java/com/hitherejoe/vineyard/ui/widget/VideoCardView.java)
 
 <p align="center">
     <img src="images/video_card_view.gif" alt="Video Card View"/>
@@ -103,14 +103,14 @@ of the following components:
 - [Looping Video View](/app/src/main/java/com/hitherejoe/vineyard/ui/widget/LoopingVideoView.java) - This is a custom VideoView that automatically loops a video without sound.
 - [Preview Card View](/app/src/main/java/com/hitherejoe/vineyard/ui/widget/PreviewCardView.java) - This is the layout class used by the video card view.
 
-##[Pagination Adapter](/app/src/main/java/com/hitherejoe/vineyard/ui/adapter/PaginationAdapter.java)
+## [Pagination Adapter](/app/src/main/java/com/hitherejoe/vineyard/ui/adapter/PaginationAdapter.java)
 
 Here I created a custom adapter by extending the standard ArrayObjectAdapter to allow the application
 to handle pagination requests. When the final item in a row of Posts becomes focused, the paginated
 request is triggered and the [Loading Card View](/app/src/main/java/com/hitherejoe/vineyard/ui/widget/LoadingCardView.java) is displayed
 until the results are returned.
 
-##[Loading Card View](/app/src/main/java/com/hitherejoe/vineyard/ui/widget/LoadingCardView.java)
+## [Loading Card View](/app/src/main/java/com/hitherejoe/vineyard/ui/widget/LoadingCardView.java)
 
 The Loading Card View again extends the BaseCardView class and is a simple cardview that displays
 a loading indicator to the user. This is used when Pagination is in use (using the PaginationAdapter)
@@ -120,7 +120,7 @@ to notify the user that Posts are being loaded.
     <img src="images/loading.gif" alt="Loading Card"/>
 </p>
 
-##[Tag Card View](/app/src/main/java/com/hitherejoe/vineyard/ui/widget/TagCardView.java)
+## [Tag Card View](/app/src/main/java/com/hitherejoe/vineyard/ui/widget/TagCardView.java)
 
 The Tag Card View again extends the BaseCardView class and is a simple cardview that displays either
 a hashtag or username. This is used to display the search results in the SearchFragment.
@@ -129,7 +129,7 @@ a hashtag or username. This is used to display the search results in the SearchF
     <img src="images/tag_card.png" alt="Tag Card"/>
 </p>
 
-##[Icon Card View](/app/src/main/java/com/hitherejoe/vineyard/ui/widget/IconCardView.java)
+## [Icon Card View](/app/src/main/java/com/hitherejoe/vineyard/ui/widget/IconCardView.java)
 
 The Icon Card View again extends the BaseCardView class and is an interactable cardview that can be used to
 display an icon with both a title and description. Currently I use this for several different situations:
@@ -152,7 +152,7 @@ display an icon with both a title and description. Currently I use this for seve
     <img src="images/check_again_card.png" alt="Check Again Card"/>
 </p>
 
-#Building
+# Building
 
 To build, install and run a debug version, run this from the root of the project:
 
@@ -164,7 +164,7 @@ To run the unit tests for the application:
 
 ````./gradlew testDebugUnitTest```
 
-#User Interface Tests
+# User Interface Tests
 
 To run the user interface tests for the application:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
